### PR TITLE
Restore root `<div>`

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -7,6 +7,6 @@
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">
-    %sveltekit.body%
+    <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/src/lib/components/JobCard.svelte
+++ b/src/lib/components/JobCard.svelte
@@ -80,7 +80,7 @@
 </style>
 
 <div class="card">
-  <a class="card-link" href="jobs/{job.id}">
+  <a class="card-link" href="/jobs/{job.id}">
     <h3 class="card-title">
       {job.title}
     </h3>


### PR DESCRIPTION
Because you will be warned if you delete the root `<div>` "as your app may break for users who have certain browser extensions installed."

This PR reverts commit 822ece4.